### PR TITLE
feat: [FFBV-81] 유저 정보 수정 API 구현

### DIFF
--- a/src/main/java/com/halggeol/backend/security/service/AuthServiceImpl.java
+++ b/src/main/java/com/halggeol/backend/security/service/AuthServiceImpl.java
@@ -79,7 +79,7 @@ public class AuthServiceImpl implements AuthService {
         if (!passwords.isPasswordConfirmed()) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다.");
         }
-        userMapper.updatePassword(user.getUsername(), passwordEncoder.encode(passwords.getNewPassword()));
+        userMapper.updatePasswordByEmail(user.getUsername(), passwordEncoder.encode(passwords.getNewPassword()));
         return Map.of("Message", "비밀번호가 변경되었습니다.");
     }
 
@@ -104,7 +104,7 @@ public class AuthServiceImpl implements AuthService {
         if (!passwords.isPasswordConfirmed()) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다.");
         }
-        userMapper.updatePassword(jwtManager.getEmail(token), passwordEncoder.encode(passwords.getNewPassword()));
+        userMapper.updatePasswordByEmail(jwtManager.getEmail(token), passwordEncoder.encode(passwords.getNewPassword()));
         return Map.of("Message", "비밀번호가 변경되었습니다.");
     }
 

--- a/src/main/java/com/halggeol/backend/user/controller/UserController.java
+++ b/src/main/java/com/halggeol/backend/user/controller/UserController.java
@@ -1,5 +1,7 @@
 package com.halggeol.backend.user.controller;
 
+import com.halggeol.backend.security.domain.CustomUser;
+import com.halggeol.backend.user.dto.EditProfileDTO;
 import com.halggeol.backend.user.dto.EmailDTO;
 import com.halggeol.backend.user.dto.UserJoinDTO;
 import com.halggeol.backend.user.service.UserService;
@@ -9,6 +11,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -18,12 +22,12 @@ import org.springframework.web.bind.annotation.RestController;
 @Log4j2
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/signup")
+@RequestMapping("/api")
 public class UserController {
     private final UserService userService;
 
     // 회원가입 요청 (이메일 본인 인증) API
-    @PostMapping("/request")
+    @PostMapping("/signup/request")
     public ResponseEntity<Map<String, String>> requestJoin(
         @Valid @RequestBody EmailDTO email
     ) {
@@ -31,11 +35,19 @@ public class UserController {
     }
 
     // 회원가입 등록 API
-    @PostMapping("")
+    @PostMapping("/signup")
     public ResponseEntity<Map<String, String>> join(
         @Valid @RequestBody UserJoinDTO user,
         @RequestParam String token
     ) {
         return ResponseEntity.status(HttpStatus.CREATED).body(userService.join(user, token));
+    }
+
+    @PatchMapping("/me")
+    public ResponseEntity<Map<String, String>> editProfile(
+        @AuthenticationPrincipal CustomUser user,
+        @Valid @RequestBody EditProfileDTO info
+    ) {
+        return ResponseEntity.ok(userService.editProfile(user, info));
     }
 }

--- a/src/main/java/com/halggeol/backend/user/dto/EditProfileDTO.java
+++ b/src/main/java/com/halggeol/backend/user/dto/EditProfileDTO.java
@@ -1,0 +1,19 @@
+package com.halggeol.backend.user.dto;
+
+import com.halggeol.backend.security.util.RegexConstants;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class EditProfileDTO {
+    @NotBlank
+    @Pattern(regexp = RegexConstants.PHONE_PATTERN)
+    private String phone;
+}

--- a/src/main/java/com/halggeol/backend/user/mapper/UserMapper.java
+++ b/src/main/java/com/halggeol/backend/user/mapper/UserMapper.java
@@ -9,16 +9,21 @@ import org.apache.ibatis.annotations.Param;
 public interface UserMapper {
     User findByEmail(String email);
 
-    int insert(User user);
-
     String findNameById(int id);
+
+    User findById(int id);
 
     List<String> findEmailByNameAndPhone(@Param("name") String name, @Param("phone") String phone);
 
-    int updatePassword(
+    int insert(User user);
+
+    int updatePasswordByEmail(
         @Param("email") String email,
         @Param("newPassword") String newPassword
     );
 
-    User findById(int id);
+    int updateProfileById(
+        @Param("id") int id,
+        @Param("phone") String phone
+    );
 }

--- a/src/main/java/com/halggeol/backend/user/service/UserService.java
+++ b/src/main/java/com/halggeol/backend/user/service/UserService.java
@@ -1,5 +1,7 @@
 package com.halggeol.backend.user.service;
 
+import com.halggeol.backend.security.domain.CustomUser;
+import com.halggeol.backend.user.dto.EditProfileDTO;
 import com.halggeol.backend.user.dto.EmailDTO;
 import com.halggeol.backend.user.dto.UserJoinDTO;
 import java.util.Map;
@@ -15,4 +17,6 @@ public interface UserService {
     Map<String, String> join(UserJoinDTO user, String token);
 
     String getNameById(int userId);
+
+    Map<String, String> editProfile(CustomUser user, EditProfileDTO info);
 }

--- a/src/main/java/com/halggeol/backend/user/service/UserServiceImpl.java
+++ b/src/main/java/com/halggeol/backend/user/service/UserServiceImpl.java
@@ -1,10 +1,12 @@
 package com.halggeol.backend.user.service;
 
+import com.halggeol.backend.security.domain.CustomUser;
 import com.halggeol.backend.security.domain.User;
 import com.halggeol.backend.security.mail.domain.MailType;
 import com.halggeol.backend.security.mail.dto.MailDTO;
 import com.halggeol.backend.security.mail.service.MailService;
 import com.halggeol.backend.security.util.JwtManager;
+import com.halggeol.backend.user.dto.EditProfileDTO;
 import com.halggeol.backend.user.dto.EmailDTO;
 import com.halggeol.backend.user.dto.UserJoinDTO;
 import com.halggeol.backend.user.mapper.UserMapper;
@@ -76,5 +78,11 @@ public class UserServiceImpl implements UserService {
     public String getNameById(int userId) {
         // 사용자 ID로 사용자 이름을 조회하는 메서드
         return userMapper.findNameById(userId);
+    }
+
+    @Override
+    public Map<String, String> editProfile(CustomUser user, EditProfileDTO info) {
+        userMapper.updateProfileById(user.getUser().getId(), info.getPhone());
+        return Map.of("Message", "사용자 정보 수정이 완료되었습니다.");
     }
 }

--- a/src/main/resources/com/halggeol/backend/user/mapper/UserMapper.xml
+++ b/src/main/resources/com/halggeol/backend/user/mapper/UserMapper.xml
@@ -9,25 +9,29 @@
     SELECT * FROM users WHERE email = #{email}
   </select>
 
-  <insert id="insert">
-    INSERT INTO users (email, name, password, phone, birth, reg_date, klg_renew_date, risk_renew_date, docu_renew_date)
-    VALUES(#{email}, #{name}, #{password}, #{phone}, #{birth}, now(), now(), now(), now())
-  </insert>
-
   <select id="findNameById" resultType="java.lang.String">
     SELECT name FROM users WHERE id = #{id}
+  </select>
+
+  <select id="findById" resultType="com.halggeol.backend.security.domain.User">
+    SELECT * FROM users WHERE id = #{id}
   </select>
 
   <select id="findEmailByNameAndPhone" resultType="java.lang.String">
     SELECT email FROM users WHERE name = #{name} AND phone = #{phone}
   </select>
 
-  <update id="updatePassword">
+  <insert id="insert">
+    INSERT INTO users (email, name, password, phone, birth, reg_date, klg_renew_date, risk_renew_date, docu_renew_date)
+    VALUES(#{email}, #{name}, #{password}, #{phone}, #{birth}, now(), now(), now(), now())
+  </insert>
+
+  <update id="updatePasswordByEmail">
     UPDATE users SET password = #{newPassword} WHERE email = #{email}
   </update>
 
-  <select id="findById" resultType="com.halggeol.backend.security.domain.User">
-    SELECT * FROM users WHERE id = #{id}
-  </select>
+  <update id="updateProfileById">
+    UPDATE users SET phone = #{phone} WHERE id = #{id}
+  </update>
 
 </mapper>


### PR DESCRIPTION
## 📌 요약

- 유저 정보 수정 API 구현 및 테스트 완료
- userMapper 종류별로 순서 수정

## 📝 상세 내용

유저 정보 수정 API 구현 및 테스트 완료
- EditProfileDTO 추가
- UserMapper에 updateProfileById 추가
- UserController/UserService에 editProfile 추가

## 🗣️ 질문 및 이외 사항

-

### ☑️ 누구에게 리뷰를 요청할까요?

-
